### PR TITLE
Update session_params error handling to specify 'Unimplemented' for unsupported 'redundancy'

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -74,7 +74,7 @@ message ModifyRequest {
   // (http://tinyurl.com/grpc-status-proto)
   // status.code is set to
   //  - UNIMPLEMENTED when it encounters an unsupported `persistence`
-  //    or `ack_type`
+  //    or `ack_type` or `redundancy`
   //  - FAILED_PRECONDITION for the other cases
   // status.details is filled with the ModifyRPCErrorDetails message with
   // an appropriate `reason`.


### PR DESCRIPTION
* (M) v1/proto/gribi.proto
 - Makes it consistent with the behavior for unsupported 'ack_type', 'persistence' and seems
   like the sensible thing to do.