### PR TITLE
Specify behavior when election_id is 0

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -109,6 +109,9 @@ message ModifyRequest {
   // to the client and responds with FAILED_PRECONDITION in
   // status.proto's `code` and sets ModifyRPCErrorDetails.reason
   // to ELECTION_ID_IN_ALL_PRIMARY
+  // The election_id MUST be non zero. When a network element receives
+  // an election_id of 0, it closes the stream with status.code
+  // set to INVALID_ARGUMENT
   Uint128 election_id = 3; 
 }
 


### PR DESCRIPTION
- Specify that election_id MUST be non zero and the server closes the stream if it receives 0.