### PR TITLE
Replace 'closes connection' with 'closes stream' 

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -105,10 +105,10 @@ message ModifyRequest {
   // the network element. AFT operations from non-primary clients
   // are discarded.
   // If the client redundancy mode is ALL_PRIMARY, but a client
-  // sends election_id, the network element closes the connection
-  // to the client and responds with FAILED_PRECONDITION in
+  // sends election_id, the network element closes the Modify RPC
+  // stream, sets FAILED_PRECONDITION in
   // status.proto's `code` and sets ModifyRPCErrorDetails.reason
-  // to ELECTION_ID_IN_ALL_PRIMARY
+  // to ELECTION_ID_IN_ALL_PRIMARY.
   // The election_id MUST be non zero. When a network element receives
   // an election_id of 0, it closes the stream with status.code
   // set to INVALID_ARGUMENT

--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -109,6 +109,9 @@ message ModifyRequest {
   // to the client and responds with FAILED_PRECONDITION in
   // status.proto's `code` and sets ModifyRPCErrorDetails.reason
   // to ELECTION_ID_IN_ALL_PRIMARY
+  // The election_id MUST be non zero. When a network element receives
+  // an election_id of 0, it closes the stream with status.code
+  // set to INVALID_ARGUMENT
   Uint128 election_id = 3; 
 }
 


### PR DESCRIPTION
To fix #10, replace the text in gribi.proto that talks about closing the connection to the client to closing the stream to avoid confusion.