### PR TITLE
Update gribi.proto

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -117,7 +117,9 @@ message ModifyRequest {
   // to ELECTION_ID_IN_ALL_PRIMARY.
   // The election_id MUST be non zero. When a network element receives
   // an election_id of 0, it closes the stream with status.code
-  // set to INVALID_ARGUMENT
+  // set to INVALID_ARGUMENT.
+  // The election_id can only be increased monotonically by a client 
+  // during a RPC session. This simplifies server implementation.
   Uint128 election_id = 3;
 }
 


### PR DESCRIPTION
Calls out that election_id can only be increased monotonically by a client during a RPC session.