### PR TITLE
Clarify network_instance in AFTOperation

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -138,7 +138,11 @@ message AFTOperation {
   // case that are multiple operations within the AFT.
   uint64 id = 1;
 
-  // Network Instance (aka vrf aka routing-instance) to apply to
+  // Network Instance (aka vrf aka routing-instance) to apply to. 
+  // If it is not specified, or is the empty string "",
+  // then the request is considered invalid and the server should
+  // respond with the INVALID_ARGUMENT error code in the status.proto
+  // carried along with the RPC response.
   string network_instance = 2;
 
   // The operation that this request is - either add, replace, or delete


### PR DESCRIPTION
Explicitly call out that a `AFTOperation` needs to always have `network_instance` specified, because the following reasons: 
* If we expect controller do the due diligent of maintaining right `AFTOperation` orderings, we should also expect the controller to know which instance it meant to modify.  
* Keep the requirement/behavior consistent with other RPC calls. For example, both `GetRequest` and `FlushRequest` requires the `network_instance` to be explicitly specified. 