### PR TITLE
Clarify expectations of AFTOperation processing 

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -52,12 +52,12 @@ service gRIBI {
 message ModifyRequest {
   // A group of requests to add/modify/remove a single AFT entry.
   //
-  // A server is expected to:
-  //  * process AFTOperations per the received order.
-  //  * not close the RPC session due to errors encountered in an AFTOperation.
+  // A gRIBI server :
+  //  * Should process AFTOperations per the received order.
+  //  * Should not close the RPC session due to errors encountered in an AFTOperation.
   //    Invalid AFTOperations should be responded to with failures within
   //    the stream.
-  //  * not have to finish pending AFTOperations if existing RPC session is
+  //  * May finish pending AFTOperations if existing RPC session is
   //    dropped/closed/cancelled.
   repeated AFTOperation operation = 1;
 

--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -54,9 +54,9 @@ message ModifyRequest {
   //
   // A gRIBI server :
   //  * Should process AFTOperations per the received order.
-  //  * Should not close the RPC session due to errors encountered in an AFTOperation.
-  //    Invalid AFTOperations should be responded to with failures within
-  //    the stream.
+  //  * Should not close the RPC session due to errors encountered in an
+  //    AFTOperation. Invalid AFTOperations should be responded to with
+  //    failures within the stream.
   //  * May finish pending AFTOperations if existing RPC session is
   //    dropped/closed/cancelled.
   repeated AFTOperation operation = 1;

--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -50,7 +50,10 @@ service gRIBI {
 // ModifyRequest is a message used by the client to manipulate the state of
 // the RIB on the target device.
 message ModifyRequest {
-  // A group of requests to add/modify/remove a single AFT entry
+  // A group of requests to add/modify/remove a single AFT entry.
+  // gRIBI server relies on clients being conservative in what they send.
+  // As such, gRIBI server is expected to process the AFTOperations per the
+  // received order.
   repeated AFTOperation operation = 1;
 
   // Meta information that the external entity sends to the network

--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -52,15 +52,13 @@ service gRIBI {
 message ModifyRequest {
   // A group of requests to add/modify/remove a single AFT entry.
   //
-  // gRIBI server relies on clients being conservative in what they send.
-  // As such, when processing AFTOperations, a gRIBI server is expected to:
+  // A server is expected to:
   //  * process AFTOperations per the received order.
-  //  * try not to close the RPC session due to errors in AFTOperation
-  //    processing (e.g. invalid network instance, unsupported op, etc), unless
-  //    it’s considered fatal to the device (e.g. might crash the whole device
-  //    routing daemon).
-  //  * not have to finish processing pending AFTOperations if existing RPC
-  //    session is dropped/closed/cancelled.
+  //  * not close the RPC session due to errors encountered in an AFTOperation.
+  //    Invalid AFTOperations should be responded to with failures within
+  //    the stream.
+  //  * not have to finish pending AFTOperations if existing RPC session is
+  //    dropped/closed/cancelled.
   repeated AFTOperation operation = 1;
 
   // Meta information that the external entity sends to the network


### PR DESCRIPTION
Add clarification of how a server should process the AFTOperations.

Some of the reasonings have been been delivered via the [motivation.md](https://github.com/openconfig/gribi/blob/master/doc/motivation.md#logic-for-limited-validation) and other issue discussions (e.g. https://github.com/openconfig/gribigo/issues/118#issuecomment-1054670468)
