### PR TITLE
Clarify handling responses during client failover

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -113,6 +113,11 @@ message ModifyRequest {
   // conidered master, in order to allow for a client to reconnect
   // without an external election having taken place.
   //
+  // After the master role failover between clients, it is ok for
+  // the server to continue sending response to previous master for
+  // requests sent by previous master. The new master is respnosible
+  // for its own reconciliation (e.g. via Get() and Modify()).
+  //
   // Only AFT operations from the primary client are acted upon by
   // the network element. AFT operations from non-primary clients
   // are not actioned, and a failure response is sent to the client.

--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -114,9 +114,9 @@ message ModifyRequest {
   // without an external election having taken place.
   //
   // After the master role failover between clients, it is ok for
-  // the server to continue sending response to previous master for
-  // requests sent by previous master. The new master is respnosible
-  // for its own reconciliation (e.g. via Get() and Modify()).
+  // the server to continue sending responses to previous master for
+  // requests sent by previous master before the failover. The new master
+  // is respnosible for its own reconciliation (e.g. via Get() and Modify()).
   //
   // Only AFT operations from the primary client are acted upon by
   // the network element. AFT operations from non-primary clients


### PR DESCRIPTION
We expect clients take the responsibility of handling failover smoothly. For example, the client can wait till all responses are received by the master before initial the failover.

Following the principle, we should be ok with the server continue sending responses to previous master for requests that sent before the failover. 