### PR TITLE
Populate Flush section

### DIFF
--- a/doc/specification.md
+++ b/doc/specification.md
@@ -138,7 +138,7 @@ Implications:
 
 The `Flush` RPC is an unary RPC for clients to remove gRIBI entries from a device. A client sends a `FlushRequest` message specifying the target network instance where the device should remove all gRIBI entries. The device processes the request and responds a `FlushResponse` message indicating the execution result.
 
-The `Flush` RPC can be used in some emergecy process to get the device out of bad traffic state, therefore:
+The `Flush` RPC can be used in some emergency process to get the device out of undesirable routing state, therefore:
 * This RPC provides a low complexity method to remove all gRIBI entries in specified network instance.
 * This RPC allows non primary client (in `SINGLE_PRIMARY` mode) to remove all gRIBI entries in specified network instance.
 

--- a/doc/specification.md
+++ b/doc/specification.md
@@ -4,7 +4,7 @@
 **Version**: 1.0.0  
 **Last Update**: 2021-11-29  
 
-## Introduction
+# 1 Introduction
 
 This document defines the specification for the gRPC Routing Information Base Interface (gRIBI). gRIBI is a gRPC-based protocol for injecting routing entries
 to a network device.
@@ -14,7 +14,29 @@ server, or target) throughout this document, and interacted with by an external
 process, referred to as the client in this document, which may be an element of
 an SDN controller.
 
+This document serves as a specification for the gRIBI protocol.
+
+# 2 Data Model
+Uses AFT OC model.
+
+## 2.1 `NextHopGroup`
+
+* `BackupNextHopGroup` operation - when to use backup vs. primary
+* Weights - expectations for quantisation
+
+## 2.2 `NextHop`
+`
+* Validation of next-hops
+* resolution outside of gRIBI
+
+# 3 Encryption, Authentication and Authorization.
+
+TLS
+
+# 4 Service Definition
+
 The gRIBI service is defined as a single gRPC service, with three RPCs:
+
  * `Modify` - a bidirectional stream RPC which is used by the client to inject
    routing entries to the server - each part of an individual operation. The 
    server responds asynchronously to these operations with an acknowledgement
@@ -24,9 +46,7 @@ The gRIBI service is defined as a single gRPC service, with three RPCs:
  * `Flush` - a unary RPC that is used as a low-complexity means to remove
    entries from a server.
 
-This document serves as a specification for the gRIBI protocol.
-
-## The `Modify` RPC
+## 4.1 The `Modify` RPC
 
 High-level description of `Modify` semantics.
 
@@ -38,22 +58,24 @@ High-level description of `Modify` semantics.
   * error handling for missing entries
   * error handling for forward references
 
-### Life cycle of a modify operation
+### 4.1.1 Life cycle of a modify operation
+
 Starts when a client creates it, and ends when the device either succeeds or returns failure of the operation. 
 
-### Forward References
+### 4.1.2 Forward References
+
 * Ability to NACK forward references
 * Server ability for resolving forward references is not required.
 * Client's responsibility to send AFTOperations in correct order.
 
-### Session Negotiation
+### 4.1.3 Session Negotiation
 
 * Message flow
   * Must be the first message.
   * Client sends `params`, server responds with if acceptable or not.
 * Semantics of each field in `params`.
 
-### Redundancy Modes
+### 4.1.4 Redundancy Modes
 
 * `ALL_PRIMARY`
   * Means to determine which entry is master.
@@ -62,7 +84,7 @@ Starts when a client creates it, and ends when the device either succeeds or ret
   * Behaviours with invalid election IDs
   * Failover behaviors. Upon discovering client failover, the device SHOULD cancel pending AFTOperations from the previous master. Results for AFTOperations from the previous master MUST NOT be sent to the acquiring new master.
 
-### `election_id` semantics
+### 4.1.5 `election_id` semantics
 
 * Updates
   * client sends modify request specifying only `election_id`, server stores
@@ -70,7 +92,7 @@ Starts when a client creates it, and ends when the device either succeeds or ret
   * client specifies `election_id` in operation.
   * behaviours when negative cases do not match.
 
-### Persistence modes
+### 4.1.6 Persistence modes
 
 * `PRESERVE`
   * across client connections - reconciliation requirement for a client.
@@ -83,7 +105,7 @@ Starts when a client creates it, and ends when the device either succeeds or ret
    * client liveliness
    * potential gRPC keepalives
 
-### Acknowledging Operations
+### 4.1.7 Acknowledging Operations
 
 * FIB ACK vs. RIB ACK
 * When an ACK is sent to the client.
@@ -94,36 +116,25 @@ Starts when a client creates it, and ends when the device either succeeds or ret
 * coaelscion - must ACK every operation ID
 * acknowledging entries in the presence of other protocol routes.
 
-Timestamping operations.
+### 4.1.8 Timestamping operations.
 
-## The `Get` RPC
-
-## `Get` semantics
-* Contains ACKed entries installed by any client
-* Performance expectations - repeated and reconciliation
-* Relationship to `openconfig-aft` telemetry
-* If the specified network instances have no installed gRIBI objects, return an empty list instead of an error.
-
-## The `Flush` RPC
-* Modes of operation - emergency client vs. elected master.
-* override behaviours
-
-## gRIBI AFT Payloads
-
-### `NextHopGroup`
-
-* `BackupNextHopGroup` operation - when to use backup vs. primary
-* Weights - expectations for quantisation
-
-### `NextHop`
-
-* Validation of next-hops
-* resolution outside of gRIBI
-
-## About gRIBI server caching
+### 4.1.9 About gRIBI Server Caching
 gRIBI server implementation is not required to cache all installed objects.
 Implications:
   * When a VRF is removed (e.g. accidentally by user via cli):
     * The device is not required to maintain gRIBI objects in the FIB or RIB.
     * Get() or Flush() should return failed (because the VRF is no longer there)
     * When the VRF is added back, the server is not required to restore all the gRIBI objects by itself.
+
+
+## 4.2 The `Get` RPC
+
+## 4.2.1 `Get` semantics
+* Contains ACKed entries installed by any client
+* Performance expectations - repeated and reconciliation
+* Relationship to `openconfig-aft` telemetry
+* If the specified network instances have no installed gRIBI objects, return an empty list instead of an error.
+
+## 4.3 The `Flush` RPC
+* Modes of operation - emergency client vs. elected master.
+* override behaviours


### PR DESCRIPTION
* Drafted the `Flush` RPC section, with the following "caveats":
  * The difference between `server` and `device` are not cleared defined yet.
  * The word `gRIBI entry` is not yet clearly defined.
  * Wording is not fully optimized. 