### PR TITLE
Add a section about election ID reset.

### DIFF
--- a/doc/specification.md
+++ b/doc/specification.md
@@ -77,6 +77,12 @@ Otherwise, the device discards the `AFTOperation` and returns a `ModifyResponse`
 
 `ModifyRequest.election_id` MUST be non zero. When a device receives an value of 0, it should close the `Modify` RPC and set `Status.code` to `INVALID_ARGUMENT`. The election ID can only be increased monotonically by a client during a RPC session. This simplifies server implementation.
 
+#### 4.1.2.1 Election ID Reset
+
+There is no requirement for clients to reset the election ID to 0 in any cases. If clients lose track of the highest election ID known by the device, clients can learn the value via `ModifyResponse.election_id` from the device (see x.y.z for more details).
+
+It is possible that in some scenarios (e.g., daemon crash, device reboot) the device might lose the highest learned election ID and hence set the value to 0. However, a device SHOULD NOT promptly reset the value to 0 in any cases(e.g., all clients disconnect). This helps reduce the chaince of non-primary client programming the device in some failure scenarios (e.g., some error happens on clients side that might lead to split-brain among clients and also cause all clients disconnect and then reconnect).
+
 ### 4.1.3 AFTOperation
 
 A client expresses modifications to the RIB modification by sending a set of `AFTOperation` messages. Three types of operations are supported:


### PR DESCRIPTION
Add a section about Election ID reset, with the following "caveats"
  * The difference between `server` and `device` are not cleared defined yet.
  * Wording is not fully optimized.
  * Line is not wrapped yet at 80. (will do it in one PR later for all sections.) 