### PR TITLE
Update DELETE

### DIFF
--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -174,8 +174,9 @@ message AFTOperation {
     // the relevant fields, such that existing entry is completely replaced
     // with the specified entry.
     REPLACE = 2;
-    // DELETE removes an entry from the table, it should fail if the entry
-    // does not exist.
+    // DELETE removes an entry from the table. It should be idempotent that it
+    // should not fail if the entry does not exist or if there is another
+    // pending deletion for the same.
     DELETE = 3;
   }
   Operation op = 3;

--- a/v1/proto/service/gribi.proto
+++ b/v1/proto/service/gribi.proto
@@ -174,9 +174,10 @@ message AFTOperation {
     // the relevant fields, such that existing entry is completely replaced
     // with the specified entry.
     REPLACE = 2;
-    // DELETE removes an entry from the table. It should be idempotent that it
-    // should not fail if the entry does not exist or if there is another
-    // pending deletion for the same.
+    // DELETE removes an entry from the table. It should be idempotent as to
+    // the table state. The idempotent behavior should also cover the response.
+    // For example, if the entry does not exist, the device should return
+    // FIB_PROGRAMMED (in the session of ack_type=RIB_AND_FIB_ACK).
     DELETE = 3;
   }
   Operation op = 3;


### PR DESCRIPTION
Expand the idempotent behavior to cover DELETE response. 

It is normal and expected that in some cases controllers would send repeated DELETE, or send DELETE while one is still pending processing on the device. We'd like to not returning errors/failures in the above scenarios, for the following reasons:

* We don't have proper error codes to represent the above scenarios
  * It is not an event/scenario that needs the same level of attention as if receiving `FAILED` or `FIB_FAILED`. 
  * The error is not fatal enough to populate `ModifyRPCErrorDetails` to disconnect the stream.

* We don't see an urgent need yet to enrich the `AFTResult` for the above scenario. It's nontrivial work to define and implement new error codes for the scenario. 
