### PR TITLE
Add a temporary fork of the setup-proto action.

### DIFF
--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Install protobuf
-        uses: arduino/setup-protoc@v1
+        uses: robshakir/setup-protoc@v1
         with:
           version: '3.x'
 

--- a/.github/workflows/genproto.yml
+++ b/.github/workflows/genproto.yml
@@ -17,6 +17,7 @@ jobs:
         uses: robshakir/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,7 @@ jobs:
         uses: robshakir/setup-protoc@v1
         with:
           version: '3.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Install protobuf
-        uses: arduino/setup-protoc@v1
+        uses: robshakir/setup-protoc@v1
         with:
           version: '3.x'
 


### PR DESCRIPTION
```
 * (M) .github/workflows/genproto.yml
  - Until https://github.com/arduino/setup-protoc/issues/59 is fixed
    then we need a fork of the repo that has a release tag and uses
    Node 16.
```

This PR fixes the CI that is failing for gRIBI. It depends on a fork which can be removed when upstream https://github.com/arduino/setup-protoc/issues/59 is fixed.
